### PR TITLE
feat: Update workflows to use S3 backend and add examples

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   deploy:
     name: Progressive Deployment
-    uses: aws-samples/aws-terraform-reusable-workflow/.github/workflows/terraform-reusable.yml@v1.2.0
+    uses: aws-samples/aws-terraform-reusable-workflow/.github/workflows/terraform-reusable.yml@v1.3.0
     strategy:
       max-parallel: 1
       fail-fast: true
@@ -37,11 +37,12 @@ jobs:
     with:
       deploy: true
       tf-version: ${{ vars.TF_VERSION }}
-      tf-organization: ${{ vars.TF_ORGANIZATION }}
-      tf-hostname: ${{ vars.TF_HOSTNAME }}
-      tf-workspace: ${{ vars.APP_NAME }}-${{ matrix.environment }}
       aws-region: ${{ matrix.region }}
       environment: ${{ matrix.environment }}
-      ref: v1.2.0
+      ref: v1.3.0
+      local-execution-mode: true
+      enable-github-modules: true
     secrets:
-      tf-token: ${{ secrets.TF_TOKEN }}
+      terraform-execution-iam-plan-role-arn: ${{ secrets.TF_PLAN_ROLE_ARN }}
+      terraform-execution-iam-apply-role-arn: ${{ secrets.TF_APPLY_ROLE_ARN }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   destroy:
     name: Progressive Destroy
-    uses: aws-samples/aws-terraform-reusable-workflow/.github/workflows/terraform-reusable.yml@v1.2.0
+    uses: aws-samples/aws-terraform-reusable-workflow/.github/workflows/terraform-reusable.yml@v1.3.0
     strategy:
       max-parallel: 1
       fail-fast: true
@@ -27,11 +27,12 @@ jobs:
     with:
       deploy: false
       tf-version: ${{ vars.TF_VERSION }}
-      tf-organization: ${{ vars.TF_ORGANIZATION }}
-      tf-hostname: ${{ vars.TF_HOSTNAME }}
-      tf-workspace: ${{ vars.APP_NAME }}-${{ matrix.environment }}
       aws-region: ${{ matrix.region }}
       environment: ${{ matrix.environment }}
-      ref: v1.2.0
+      ref: v1.3.0
+      local-execution-mode: true
+      enable-github-modules: true
     secrets:
-      tf-token: ${{ secrets.TF_TOKEN }}
+      terraform-execution-iam-plan-role-arn: ${{ secrets.TF_PLAN_ROLE_ARN }}
+      terraform-execution-iam-apply-role-arn: ${{ secrets.TF_APPLY_ROLE_ARN }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/terraform-test-pr.yml
+++ b/.github/workflows/terraform-test-pr.yml
@@ -1,6 +1,7 @@
 name: Terraform test PR
 
 permissions:
+  id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout
   deployments: write # This is required to deactivate deployments
 
@@ -29,15 +30,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.TF_PLAN_ROLE_ARN }}
+          role-session-name: terraform-test-role
+          aws-region: us-east-1
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
       - name: Terraform Init
         run: terraform init
-        env:
-          TF_CLOUD_ORGANIZATION: ${{ vars.TF_ORGANIZATION }}
-          TF_CLOUD_HOSTNAME: ${{ vars.TF_HOSTNAME }}
-          TF_WORKSPACE: ${{ vars.APP_NAME }}-terraform-test
-          TF_TOKEN_app_terraform_io: ${{ secrets.TF_TOKEN }}
       - name: Terraform test
         run: terraform test
   deactivate-deployment:

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -2,14 +2,14 @@ config {
   format     = "compact"
   plugin_dir = "~/.tflint.d/plugins"
 
-  module              = false
+  call_module_type    = "local"
   force               = false
   disabled_by_default = true
 }
 
 plugin "aws" {
   enabled = true
-  version = "0.30.0"
+  version = "0.37.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ This repository provides the template to use for all Terraform Modules.
 
 - [AWS Terraform Module Template](#aws-terraform-module-template)
   - [Repository configuration checklist](#repository-configuration-checklist)
+  - [Backend Configuration](#backend-configuration)
+    - [Option 1: Terraform Cloud/Enterprise (Default)](#option-1-terraform-cloudenterprise-default)
+    - [Option 2: S3 Backend](#option-2-s3-backend)
+  - [Module Sourcing](#module-sourcing)
+    - [GitHub Module Sourcing](#github-module-sourcing)
+    - [Terraform Registry Modules](#terraform-registry-modules)
+    - [Local Modules](#local-modules)
   - [Requirements](#requirements)
   - [Providers](#providers)
   - [Modules](#modules)
@@ -18,12 +25,6 @@ This repository provides the template to use for all Terraform Modules.
   - [Outputs](#outputs)
   - [Security](#security)
   - [License](#license)
-  - [Requirements](#requirements)
-  - [Providers](#providers)
-  - [Modules](#modules)
-  - [Resources](#resources)
-  - [Inputs](#inputs)
-  - [Outputs](#outputs)
 
 <!-- /TOC -->
 
@@ -43,7 +44,202 @@ This repository provides the template to use for all Terraform Modules.
 - [ ] (Reusable module) Delete the [envs](./envs/) folder.
 - [ ] (Reusable module) Delete the [terraform.tfvars](./terraform.tfvars) file.
 - [ ] (Reusable module) Create an `examples` folder at the root of the repository where to put an example module calling the reusable module. Use a [Git URL](https://developer.hashicorp.com/terraform/language/modules/sources#generic-git-repository) selecting the latest [revision](https://developer.hashicorp.com/terraform/language/modules/sources#selecting-a-revision) to source the reusable module.
+- [ ] Configure the S3 backend in providers.tf with your bucket name, key, and region
 - [ ] Delete this checklist and start coding!
+
+## Backend Configuration
+
+This template supports two backend configuration options for storing Terraform state:
+
+### Option 1: S3 Backend (Default)
+
+The default configuration uses S3 for state management. The configuration is already set up in `providers.tf`:
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket         = "my-terraform-state-bucket"
+    key            = "path/to/my/terraform.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+    # Enable state locking with a local lock file (useful for CI/CD environments)
+    use_lock_file = true
+  }
+}
+```
+
+Update your GitHub Actions workflow to use the S3 backend:
+
+```yaml
+with:
+  deploy: true
+  tf-version: ${{ vars.TF_VERSION }}
+  aws-region: ${{ matrix.region }}
+  environment: ${{ matrix.environment }}
+  local-execution-mode: true
+  ref: v1.3.0
+```
+
+### Option 2: Terraform Cloud/Enterprise
+
+Alternatively, you can use Terraform Cloud/Enterprise for state management. To use this option:
+
+1. Delete the `backend "s3"` block and uncomment the `cloud` block in `providers.tf`:
+   ```hcl
+   terraform {
+     cloud {}
+   }
+   ```
+
+2. Update your GitHub Actions workflow with Terraform Cloud/Enterprise parameters:
+   ```yaml
+   with:
+     tf-organization: ${{ vars.TF_ORGANIZATION }}
+     tf-hostname: ${{ vars.TF_HOSTNAME }}
+     tf-workspace: ${{ vars.APP_NAME }}-${{ matrix.environment }}
+   secrets:
+     tf-token: ${{ secrets.TF_TOKEN }}
+   ```
+
+## Module Sourcing
+
+This template supports multiple methods for sourcing Terraform modules:
+
+### GitHub Module Sourcing
+
+To source modules from GitHub repositories securely:
+
+#### Public Repository Sourcing
+
+For public repositories, always use commit hashes to prevent supply chain attacks:
+
+1. Public repository root module:
+   ```hcl
+   module "example" {
+     source = "github.com/organization/repository?ref=a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0"
+
+     # Module inputs
+     example_input = "value"
+   }
+   ```
+
+2. Public repository submodule:
+   ```hcl
+   module "example" {
+     source = "github.com/organization/repository//path/to/module?ref=a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0"
+
+     # Module inputs
+     example_input = "value"
+   }
+   ```
+
+#### Private Repository Sourcing
+
+For private repositories, you can use version tags as they're within your organization's control:
+
+1. Private repository root module:
+   ```hcl
+   module "example" {
+     source = "github.com/organization/private-repository?ref=v1.0.0"
+
+     # Module inputs
+     example_input = "value"
+   }
+   ```
+
+2. Private repository submodule:
+   ```hcl
+   module "example" {
+     source = "github.com/organization/private-repository//path/to/module?ref=v1.0.0"
+
+     # Module inputs
+     example_input = "value"
+   }
+   ```
+
+#### GitHub Actions Configuration
+
+Update your GitHub Actions workflow to enable GitHub module sourcing:
+
+```yaml
+with:
+  local-execution-mode: true
+  enable-github-modules: true
+secrets:
+  github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Terraform Registry Modules
+
+#### Public Registry Modules
+
+For public registry modules, it's recommended to use the GitHub source instead of the Terraform Registry for better security control:
+
+```hcl
+# RECOMMENDED: Source directly from GitHub with commit hash pinning
+module "vpc" {
+  source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0"
+
+  # Module inputs
+  name = "my-vpc"
+  cidr = "10.0.0.0/16"
+}
+```
+
+```hcl
+# NOT RECOMMENDED: Using Terraform Registry for public modules
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.0.0"
+
+  # Module inputs
+  name = "my-vpc"
+  cidr = "10.0.0.0/16"
+}
+```
+
+Using GitHub source with commit hash pinning provides better protection against supply chain attacks compared to the Terraform Registry, as it ensures the exact code version is used and cannot be tampered with.
+
+#### Private Registry Modules
+
+For private registry modules within your organization:
+
+```hcl
+module "internal_vpc" {
+  source  = "app.terraform.io/my-organization/vpc/aws"
+  version = "1.0.0"
+
+  # Module inputs
+  name = "my-vpc"
+  cidr = "10.0.0.0/16"
+}
+```
+
+### Security Best Practices
+
+1. **Public modules**: Always pin to specific commit hashes to prevent supply chain attacks
+2. **Private modules**: Version tags are acceptable as they're within your organization's control
+3. **Avoid using branch references** as they can change over time:
+   ```hcl
+   # NOT RECOMMENDED for production
+   module "example" {
+     source = "github.com/organization/repository?ref=main"
+   }
+   ```
+4. **Regularly audit and update** pinned versions to incorporate security patches
+
+### Local Modules
+
+To source modules from local paths:
+
+```hcl
+module "local_example" {
+  source = "./modules/example"
+
+  # Module inputs
+  example_input = "value"
+}
+```
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -81,7 +277,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_hello_world"></a> [hello\_world](#output\_hello\_world) | Test output used by Terrastest |
+| <a name="output_hello_world"></a> [hello\_world](#output\_hello\_world) | Test output |
 | <a name="output_random_pet"></a> [random\_pet](#output\_random\_pet) | Dummy output |
 <!-- END_TF_DOCS -->
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "hello_world" {
-  description = "Test output used by Terrastest"
+  description = "Test output"
   value       = "Hello, ${upper(var.environment)} World!"
 }
 

--- a/providers.tf
+++ b/providers.tf
@@ -6,6 +6,24 @@ provider "aws" {
   }
 }
 
+# Terraform backend configuration
+# Option 1: S3 backend (default)
 terraform {
-  cloud {}
+  backend "s3" {
+    bucket  = "my-terraform-state-bucket"
+    key     = "path/to/my/terraform.tfstate"
+    region  = "us-east-1"
+    encrypt = true
+    # Enable state locking with a local lock file (useful for CI/CD environments)
+    use_lock_file = true
+  }
 }
+
+# Option 2: Terraform Cloud/Enterprise (alternative)
+# Delete the backend "s3" block above and uncomment the cloud block below
+# to use Terraform Cloud/Enterprise
+# terraform {
+#   cloud {}
+# }
+
+# Note: You can only have one backend configuration active at a time.


### PR DESCRIPTION
# What does this PR do?

This PR enhances the AWS Terraform template by adding S3 backend support as an alternative to Terraform Cloud/Enterprise and implementing GitHub module sourcing capability. These changes provide users with more flexibility in how they manage their Terraform state and source their modules.

## Motivation

Add S3 backend support and GitHub module sourcing capability­.

### Key Changes

1. **S3 Backend Support**:
   - Updated GitHub Actions workflows to use S3 backend configuration
   - Made Terraform Cloud/Enterprise parameters optional
   - Added documentation for S3 backend configuration

2. **GitHub Module Sourcing**:
   - Added support for sourcing modules directly from GitHub repositories
   - Implemented secure handling of GitHub credentials
   - Added documentation for GitHub module sourcing

3. **Authentication Updates**:
   - Switched from Terraform Cloud authentication to GitHub OIDC for AWS authentication
   - Added IAM role ARNs for plan and apply operations
   - Implemented secure credential handling

### Checklist

- [ ] Yes, I have executed [tests](../blob/main/CONTRIBUTING.md#execute-tests-manually) successfully.
- [x] Yes, I have updated the documentation for this change.
- [x] Yes, [pre-commit hooks](../blob/main/CONTRIBUTING.md#execute-pre-commit-hooks-manually-on-all-files) have been executed successfully.
